### PR TITLE
make main file definition work relative to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "代码比对展示(Code comparison display)",
   "author": "ddchef>",
   "private": false,
-  "main": "/dist/vue-code-diff.js",
+  "main": "dist/vue-code-diff.js",
   "typings": "types/index.d.ts",
   "keywords": [
     "vue",


### PR DESCRIPTION
for me jest could not resolve the package because of the leading slash. This should fix it.